### PR TITLE
Add test and small fix for using `joinQuery` with a nullable relation

### DIFF
--- a/src/hooks/joinQuery.js
+++ b/src/hooks/joinQuery.js
@@ -32,14 +32,8 @@ module.exports = options => {
         });
 
         const idList = matches
-          .map(match => {
-            if (match[option.targetKey].toString) {
-              return match[option.targetKey].toString();
-            } else {
-              return match[option.targetKey];
-            }
-          })
-          .filter(match => match);
+          .map(match => match[option.targetKey])
+          .filter(match => match)
 
         return {
           [option.foreignKey]: { $in: idList }

--- a/src/hooks/joinQuery.js
+++ b/src/hooks/joinQuery.js
@@ -32,7 +32,14 @@ module.exports = options => {
         });
 
         const idList = matches
-          .map(match => match[option.targetKey])
+          .map(match => {
+            const id = match[option.targetKey]
+            if (id && id.toString) {
+              return id.toString()
+            } else {
+              return id
+            }
+          })
           .filter(match => match)
 
         return {

--- a/tests/hooks/joinQuery.test.js
+++ b/tests/hooks/joinQuery.test.js
@@ -27,6 +27,37 @@ describe('joinQuery', () => {
     })
   );
 
+  app.use(
+    'api/users',
+    memory({
+      store: [
+        { id: 1, name: 'Alice' },
+      ]
+    })
+  );
+
+  app.use(
+    'api/roles',
+    memory({
+      store: [
+        { id: 10, user_id: 1, team_id: null, name: 'customer' },
+        { id: 20, user_id: 1, team_id: 1, name: 'team-member' },
+        { id: 30, user_id: 1, team_id: 2, name: 'team-lead' }
+      ]
+    })
+  )
+
+  app.use(
+    'api/teams',
+    memory({
+      store: [
+        { id: 1, name: 'teamOne' },
+        { id: 2, name: 'teamTwo' },
+        { id: 3, name: 'teamThree'}
+      ]
+    })
+  )
+
   it('Joins the query', async () => {
     const context = {
       app,
@@ -49,4 +80,32 @@ describe('joinQuery', () => {
       artist_id: { $in: [123] }
     });
   });
+
+
+  it('Can handle a nullable association field', async () => {
+    // Query: which teams have a role belonging to user_id = 1?
+    const context = {
+      app,
+      params: {
+        query: {
+          roles: {
+            user_id: 1
+          }
+        }
+      }
+    }
+
+    const newContext = await joinQuery({
+      roles: {
+        service: 'api/roles',
+        targetKey: 'team_id',
+        foreignKey: 'id'
+      }
+    })(context);
+
+    await assert.deepEqual(newContext.params.query, {
+      id: { $in: [1, 2] }
+    })
+
+  })
 });


### PR DESCRIPTION
Hello,

This PR adds a test and (maybe a breaking?) fix so that `joinQuery` hook can be used with a nullable relation.

In the previous version `.toString` was called on every `match[option.targetKey]` which would throw if the key's value was null.  The naive solution is to do no processing on `match[option.targetKey]`, which then allows the `.filter` to clean up any nulls.