### PR TITLE
Hook/join query or

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
       ]
     },
     "parserOptions": {
-      "ecmaVersion": 2017
+      "ecmaVersion": 2018
     },
     "env": {
       "es6": true

--- a/src/hooks/joinQuery.js
+++ b/src/hooks/joinQuery.js
@@ -83,27 +83,11 @@ const afterHook = (context, options) => {
     const sorted = [...results];
 
     if (baseQuery) {
-      const joinKeys = Object.keys(baseQuery);
-      joinKeys.forEach(key => {
-        const { query, foreignKeys } = baseQuery[key];
-        const option = options[key];
-        if (query.$sort) {
-          sortResults(foreignKeys, sorted, option);
-        }
-      });
+      sortByJoinQuery(baseQuery, sorted, options);
     }
 
     if (orQuery) {
-      orQuery.forEach(q => {
-        const joinKeys = Object.keys(q);
-        joinKeys.forEach(key => {
-          const { query, foreignKeys } = q[key];
-          const option = options[key];
-          if (query.$sort) {
-            sortResults(foreignKeys, sorted, option);
-          }
-        });
-      });
+      orQuery.forEach(query => sortByJoinQuery(query, sorted, options));
     }
 
     replaceResults(context, sorted);
@@ -277,6 +261,17 @@ const makeForeignKeys = (matches, option) => {
   //   }
   // });
   // return foreignKeys;
+};
+
+const sortByJoinQuery = (q, results, options) => {
+  const joinKeys = Object.keys(q);
+  joinKeys.forEach(key => {
+    const { query, foreignKeys } = q[key];
+    const option = options[key];
+    if (query.$sort) {
+      sortResults(foreignKeys, results, option);
+    }
+  });
 };
 
 const sortResults = (foreignKeys, results, option) => {

--- a/src/hooks/joinQuery.js
+++ b/src/hooks/joinQuery.js
@@ -220,7 +220,7 @@ const mergeQuery = (_query, joinQueries) => {
   return query;
 };
 
-throwIfNotFound = ({ baseQuery, orQuery }) => {
+const throwIfNotFound = ({ baseQuery, orQuery }) => {
   // All joinQueries in the baseQuery must have returned results
   if (baseQuery && !joinWasFound(baseQuery)) {
     throw new NotFound();

--- a/tests/hooks/joinQuery.test.js
+++ b/tests/hooks/joinQuery.test.js
@@ -104,9 +104,7 @@ describe('joinQuery', () => {
     });
   });
 
-  it('Does not join query if no matches', async () => {
-    // TODO: This should really throw a not found...?
-    // Query: which albums have an artist with name 'Elvis'
+  it('Throws NotFound error if no matches', async () => {
     const context = {
       app,
       type: 'before',
@@ -118,7 +116,7 @@ describe('joinQuery', () => {
       }
     };
 
-    const newContext = await joinQuery({
+    const shouldReject = joinQuery({
       artist: {
         service: 'api/artists',
         targetKey: 'id',
@@ -126,7 +124,30 @@ describe('joinQuery', () => {
       }
     })(context);
 
-    await assert.deepStrictEqual(newContext.params.query, {});
+    await assert.rejects(shouldReject, { name: 'NotFound' });
+  });
+
+  it('Throws NotFound error if no $or matches', async () => {
+    const context = {
+      app,
+      type: 'before',
+      method: 'find',
+      params: {
+        query: {
+          $or: [{ artist: { name: 'Elvis' } }]
+        }
+      }
+    };
+
+    const shouldReject = joinQuery({
+      artist: {
+        service: 'api/artists',
+        targetKey: 'id',
+        foreignKey: 'artist_id'
+      }
+    })(context);
+
+    await assert.rejects(shouldReject, { name: 'NotFound' });
   });
 
   it('Can use a custom makeKey option', async () => {
@@ -239,6 +260,50 @@ describe('joinQuery', () => {
           $sort: {
             'artist.name': 1
           }
+        }
+      }
+    };
+
+    const newBeforeContext = await joinQuery({
+      artist: {
+        service: 'api/artists',
+        targetKey: 'id',
+        foreignKey: 'artist_id'
+      }
+    })(beforeContext);
+
+    const afterContext = {
+      type: 'after',
+      method: 'find',
+      result: [
+        { id: 3, title: 'Life in Nashville', artist_id: 2 },
+        { id: 2, title: 'I Wont Back Down', artist_id: 1 }
+      ]
+    };
+
+    const newAfterContext = await joinQuery({
+      artist: {
+        service: 'api/artists',
+        targetKey: 'id',
+        foreignKey: 'artist_id'
+      }
+    })(Object.assign(newBeforeContext, afterContext));
+
+    await assert.deepStrictEqual(newAfterContext.result, [
+      { id: 2, title: 'I Wont Back Down', artist_id: 1 },
+      { id: 3, title: 'Life in Nashville', artist_id: 2 }
+    ]);
+  });
+
+  it('Can $sort on joined $or queries', async () => {
+    // Query: $sort albums by artist name
+    const beforeContext = {
+      app,
+      type: 'before',
+      method: 'find',
+      params: {
+        query: {
+          $or: [{ artist: { $sort: { name: 1 } } }]
         }
       }
     };


### PR DESCRIPTION
Builds upon @robbyphillips PR to allow using joinQueries in `$or` by updating all the orQueries to run in the same Promise.all as the baseQuery for faster execution. 

Also makes the hook throw a `NotFound` if none of the baseQueries returned results or if at least one orQuery did not return results.

Other minor improvements including less mutation in favor or "copying" and then mutating in the `cleanQuery` and `mergeQuery` functions.