### PR TITLE
Update joinQuery.ts

### DIFF
--- a/src/hooks/joinQuery.ts
+++ b/src/hooks/joinQuery.ts
@@ -331,7 +331,7 @@ const sortResults = (
 
 const paginateResults = (context: HookContext, results: any[]) => {
   const ctx = { ...context };
-  const pagination = ctx.service.options && ctx.service.options.paginate;
+  const pagination = ctx.service && ctx.service.options && ctx.service.options.paginate;
   const paginate = ctx.params && ctx.params.paginate;
   const query = ctx.params && ctx.params.query;
   const hasLimit = query && hasKey(query, '$limit');


### PR DESCRIPTION
I am running into situations where service is not available and causing the following error:

```
Running hook logError on holdings.find
error: TypeError: Cannot read properties of undefined (reading 'options')
    at paginateResults (file:///home/marcgodard/Documents/Github/swp-api/node_modules/feathers-fletching/dist/index.mjs:601:34)
    at findJoinQuerySort (file:///home/marcgodard/Documents/Github/swp-api/node_modules/feathers-fletching/dist/index.mjs:560:28)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

This PR fixes that.