### PR TITLE
Set limit to unlimited for all results in a sort with joinquery.

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -545,6 +545,7 @@ const transformJoinQuery = async (query, context, options) => {
   return query;
 };
 const findJoinQuerySort = async (query, joinSort, context, options) => {
+  if (query.$limit) query.$limit = -1;
   const transformedJoinQuery = await transformJoinQuery(
     query,
     context,

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -538,6 +538,7 @@ const transformJoinQuery = async (query, context, options) => {
   return query;
 };
 const findJoinQuerySort = async (query, joinSort, context, options) => {
+  if (query.$limit) query.$limit = -1;
   const transformedJoinQuery = await transformJoinQuery(
     query,
     context,

--- a/src/hooks/joinQuery.ts
+++ b/src/hooks/joinQuery.ts
@@ -244,6 +244,7 @@ const findJoinQuerySort = async (
   context: HookContext,
   options: JoinQueryOptionsRequired
 ) => {
+  if (query.$limit) query.$limit = -1;
   const transformedJoinQuery = await transformJoinQuery(
     query,
     context,


### PR DESCRIPTION
This fixed my join query sort, however, I see you try to make it use pagination: false but it isn't being applied and couldn't figure out how.